### PR TITLE
Print a Backtrace when catching an Exception

### DIFF
--- a/lib/kontrast/runner.rb
+++ b/lib/kontrast/runner.rb
@@ -95,6 +95,7 @@ module Kontrast
             end
         rescue Exception => e
             puts "Exception: #{e.inspect}"
+            puts e.backtrace.inspect
             if Kontrast.configuration.fail_build
                 raise e
             end


### PR DESCRIPTION
Just to make debugging easier in the future