### PR TITLE
Ensure Manifest Creation

### DIFF
--- a/bin/kontrast
+++ b/bin/kontrast
@@ -87,7 +87,7 @@ module Kontrast
                         raise ConfigurationException.new("Error parsing the config flag '#{config}'")
                     rescue LoadError => e
                         raise ConfigurationException.new("Could not load '#{config}'")
-                    rescue Exception => e
+                    rescue StandardError => e
                         raise ConfigurationException.new("An unexpected error occurred while trying to load the given config file: #{e.inspect}")
                     end
                 else

--- a/lib/kontrast.rb
+++ b/lib/kontrast.rb
@@ -30,7 +30,7 @@ module Kontrast
                 Bundler.environment.current_dependencies.each do |dep|
                     return true if dep.name == "rails"
                 end
-            rescue Exception => e
+            rescue StandardError => e
                 # Quietly ignore any exceptions
             end
             return false

--- a/lib/kontrast/gallery_creator.rb
+++ b/lib/kontrast/gallery_creator.rb
@@ -12,7 +12,7 @@ module Kontrast
         def create_gallery(output_dir)
             begin
                 @gallery_dir = FileUtils.mkdir_p("#{output_dir}/gallery").join('')
-            rescue Exception => e
+            rescue StandardError => e
                 raise GalleryException.new("An unexpected error occurred while trying to create the gallery's output directory: #{e.inspect}")
             end
 

--- a/lib/kontrast/runner.rb
+++ b/lib/kontrast/runner.rb
@@ -119,7 +119,7 @@ module Kontrast
                     else
                         raise RunnerException.new("Could not reach the test server at '#{uri}'.")
                     end
-                rescue Exception => e
+                rescue StandardError => e
                     raise RunnerException.new("An unexpected error occured while trying to reach the test server at '#{uri}': #{e.inspect}")
                 end
 
@@ -137,7 +137,7 @@ module Kontrast
                     else
                         raise RunnerException.new("Could not reach the production server at '#{uri}'.")
                     end
-                rescue Exception => e
+                rescue StandardError => e
                     raise RunnerException.new("An unexpected error occured while trying to reach the production server at '#{uri}': #{e.inspect}")
                 end
             end

--- a/lib/kontrast/runner.rb
+++ b/lib/kontrast/runner.rb
@@ -80,9 +80,15 @@ module Kontrast
                     if Kontrast.configuration.fail_build
                         raise e
                     end
+                rescue StandardError => e
+                    puts "Exception: #{e.inspect}"
+                    puts e.backtrace.inspect
+                    if Kontrast.configuration.fail_build
+                        raise e
+                    end
                 end
             end
-
+        ensure
             # Log diffs
             puts @image_handler.diffs
 
@@ -93,13 +99,7 @@ module Kontrast
             else
                 @image_handler.create_manifest(current_node)
             end
-        rescue Exception => e
-            puts "Exception: #{e.inspect}"
-            puts e.backtrace.inspect
-            if Kontrast.configuration.fail_build
-                raise e
-            end
-        ensure
+
             @selenium_handler.cleanup
         end
 


### PR DESCRIPTION
When an exception is encountered in the runner, it is rescued but the manifest doesn't get generated. This ensures that all tests are given a chance and that the manifest is always created.