### PR TITLE
Fix URL Params

### DIFF
--- a/lib/kontrast/page_test.rb
+++ b/lib/kontrast/page_test.rb
@@ -10,6 +10,8 @@ module Kontrast
             super(prefix, name, path, headers)
             @width = prefix
             @url_params = url_params
+
+            # Re-define path so it includes all URL params
             @path = get_path_with_params(url_params)
         end
 

--- a/lib/kontrast/page_test.rb
+++ b/lib/kontrast/page_test.rb
@@ -10,12 +10,15 @@ module Kontrast
             super(prefix, name, path, headers)
             @width = prefix
             @url_params = url_params
+            @path = get_path_with_params(url_params)
+        end
 
-            if url_params.any?
-                uri = URI(@path)
-                uri.query = Rack::Utils.build_query(url_params)
-                @path = uri.to_s
-            end
+        def get_path_with_params(url_params)
+            uri = URI(@path)
+            original_query = Rack::Utils.parse_query(uri.query)
+            new_query = url_params.merge(original_query)
+            uri.query = Rack::Utils.build_query(new_query)
+            return uri.to_s
         end
     end
 end

--- a/lib/kontrast/page_test.rb
+++ b/lib/kontrast/page_test.rb
@@ -18,6 +18,12 @@ module Kontrast
             original_query = Rack::Utils.parse_query(uri.query)
             new_query = url_params.merge(original_query)
             uri.query = Rack::Utils.build_query(new_query)
+
+            # Ensure there's no trailing "?"
+            if uri.query == ""
+                uri.query = nil
+            end
+
             return uri.to_s
         end
     end

--- a/lib/kontrast/version.rb
+++ b/lib/kontrast/version.rb
@@ -1,3 +1,3 @@
 module Kontrast
-    VERSION = "0.5.0"
+    VERSION = "0.5.1"
 end

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -29,4 +29,25 @@ describe Kontrast::Test do
         test = Kontrast.page_test_suite.tests.first
         expect { test.run_callback(:foo, 1) }.to raise_error(NoMethodError)
     end
+
+    context "with a URI query" do
+        before :each do
+            Kontrast.configure do |config|
+                config.pages(1280, global_key: "global_value") do |page|
+                    page.simple_path_test "/about"
+                    page.complex_path_test "/about?key=value"
+                end
+            end
+        end
+
+        it "can build a path with global URL params only" do
+            test = Kontrast.page_test_suite.tests.find { |t| t.name == "simple_path_test" }
+            expect(test.path).to eql "/about?global_key=global_value"
+        end
+
+        it "can build a path with global and local URL params" do
+            test = Kontrast.page_test_suite.tests.find { |t| t.name == "complex_path_test" }
+            expect(test.path).to eql "/about?global_key=global_value&key=value"
+        end
+    end
 end


### PR DESCRIPTION
I ran into a bug with Kontrast while trying to fix some diffs.

When I implemented the global params feature, I didn't take into account the presence of local params.

Basically the global params now override any local params and you can only set one or the other. This lets us set both.

Specs included.