### PR TITLE
Change dependency from fog to fog-aws

### DIFF
--- a/kontrast.gemspec
+++ b/kontrast.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
     spec.add_dependency "selenium-webdriver", "~> 2.0"
     spec.add_dependency "workers", "~> 0.2"
     spec.add_dependency "rmagick", "2.13.2"
-    spec.add_dependency "fog", "~> 1.0"
+    spec.add_dependency "fog-aws", "~> 0.9"
     spec.add_dependency "faraday", "~> 0.9"
     spec.add_dependency "rack", ">= 0.4"
 end

--- a/lib/kontrast.rb
+++ b/lib/kontrast.rb
@@ -1,5 +1,5 @@
 # Dependencies
-require "fog"
+require "fog/aws"
 require "bundler"
 
 # Load classes


### PR DESCRIPTION
Requiring fog will automatically include fog, fog-core, and all the
fog-x gems for ALL the providers they support.
Given that we only work with aws in this gem, being more restrictive
about what we require makes more sense.