### PR TITLE
Image Uploader: Limit concurrency to 5 'workers'

### DIFF
--- a/lib/kontrast/configuration.rb
+++ b/lib/kontrast/configuration.rb
@@ -32,6 +32,7 @@ module Kontrast
         attr_accessor :test_domain, :production_domain
         attr_accessor :browser_driver, :browser_profile
         attr_accessor :fail_build
+        attr_accessor :workers_pool_size
         attr_accessor :production_oauth_app_uid, :production_oauth_app_secret,
           :test_oauth_app_uid, :test_oauth_app_secret, :oauth_token_url,
           :oauth_token_from_response, :test_oauth_app_proc
@@ -134,6 +135,10 @@ module Kontrast
             else
                 @_after_screenshot.call(test_driver, production_driver, current_test) if @_after_screenshot
             end
+        end
+
+        def workers_pool_size
+            @workers_pool_size || 5
         end
 
         private

--- a/lib/kontrast/image_uploader.rb
+++ b/lib/kontrast/image_uploader.rb
@@ -1,7 +1,10 @@
 module Kontrast
     module ImageUploader
         def upload_images(test)
-            Workers.map(Dir.entries("#{Kontrast.path}/#{test}")) do |file|
+            worker_pool = Workers::Pool.new
+            worker_pool.resize(Kontrast.configuration.workers_pool_size)
+
+            Workers.map(Dir.entries("#{Kontrast.path}/#{test}"), pool: worker_pool) do |file|
                 next if ['.', '..'].include?(file)
                 Kontrast.fog.directories.get(Kontrast.configuration.aws_bucket).files.create(
                     key: "#{Kontrast.configuration.remote_path}/#{test}/#{file}",

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -50,4 +50,23 @@ describe Kontrast::Configuration do
             gallery: "arg2"
         })
     end
+
+    context "workers pool size" do
+        before do
+            Kontrast.configuration = nil
+            Kontrast.configure {}
+        end
+
+        it "defaults to 5" do
+            expect(Kontrast.configuration.workers_pool_size).to eq(5)
+        end
+
+        it "can be overriden" do
+            Kontrast.configure do |config|
+                config.workers_pool_size = 10
+            end
+
+            expect(Kontrast.configuration.workers_pool_size).to eq(10)
+        end
+    end
 end


### PR DESCRIPTION
We started seeing weird timeouts on our CI server when trying to upload
large-ish number of images (usually 20+).
My guess is that we're hitting the swap by trying to parallelize too
much, limiting the size of the pool to 5 workers should still give us
decent speed up while preventing us from using all the available memory.