### PR TITLE
Reduce memory usage in ThumbnailCreator

### DIFF
--- a/lib/kontrast/api_endpoint_runner.rb
+++ b/lib/kontrast/api_endpoint_runner.rb
@@ -1,7 +1,6 @@
 module Kontrast
     class ApiEndpointRunner
         include ImageUploader
-        include ThumbnailCreator
 
         attr_accessor :diffs
 
@@ -68,7 +67,7 @@ module Kontrast
                         ['.', '..'].include?(file_name) || file_name.include?('.json')
                     }
 
-                    create_thumbnails(test, images)
+                    ThumbnailCreator.create_thumbnails(test, images)
 
                     # Upload to S3
                     if Kontrast.configuration.run_parallel

--- a/lib/kontrast/page_runner.rb
+++ b/lib/kontrast/page_runner.rb
@@ -1,7 +1,6 @@
 module Kontrast
     class PageRunner
         include ImageUploader
-        include ThumbnailCreator
 
         attr_reader :diffs
 
@@ -60,7 +59,7 @@ module Kontrast
 
                     # Create thumbnails for gallery
                     print "Creating thumbnails... "
-                    create_thumbnails(test, ['test.png', 'production.png', 'diff.png'])
+                    ThumbnailCreator.create_thumbnails(test, ['test.png', 'production.png', 'diff.png'])
 
                     # Upload to S3
                     if Kontrast.configuration.run_parallel

--- a/lib/kontrast/thumbnail_creator.rb
+++ b/lib/kontrast/thumbnail_creator.rb
@@ -1,18 +1,24 @@
 module Kontrast
-    module ThumbnailCreator
+  module ThumbnailCreator
 
-        def create_thumbnails(test, image_names)
-            # Load images
-            images = image_names.map do |image|
-                Magick::Image.read(File.join(Kontrast.path, test.to_s, image)).first
-            end
+    module_function
 
-            # Crop images
-            Workers.map(images) do |image|
-                filename = image.filename.split('/').last.split('.').first + "_thumb"
-                full_path = "#{Kontrast.path}/#{test}/#{filename}.png"
-                image.resize_to_fill(200, 200, Magick::NorthGravity).write(full_path)
-            end
-        end
+    def create_thumbnails(test, image_names)
+      # Crop images
+      Workers.map(image_names) do |image_name|
+        src_path = File.join(Kontrast.path, test.to_s, image_name)
+
+        # Resize to at least 200 width, the crop the top part of the image at 200x200
+        # '+repage' means "don't keep the part of the image not shown in the crop"
+        # http://www.imagemagick.org/discourse-server/viewtopic.php?t=18545
+        options = '-resize "200x200^" -gravity North -crop 200x200+0+0 +repage'
+        `convert "#{src_path}" #{options} "#{thumb_path(test, image_name)}"`
+      end
     end
+
+    def thumb_path(test, image_name)
+        filename = "#{File.basename(image_name, ".*")}_thumb.png"
+        File.join(Kontrast.path, test.to_s, filename)
+    end
+  end
 end

--- a/lib/kontrast/version.rb
+++ b/lib/kontrast/version.rb
@@ -1,3 +1,3 @@
 module Kontrast
-    VERSION = "0.6.1"
+    VERSION = "0.6.2"
 end

--- a/spec/thumbnail_creator_spec.rb
+++ b/spec/thumbnail_creator_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+require 'kontrast'
+
+describe Kontrast::ThumbnailCreator do
+  let(:kontrast_path) { "/path/to/kontrast" }
+  let(:test) { "home_1280" }
+  let(:image_names) do
+    [
+      "diff_0.jpg",
+      "test_0.jpg",
+      "prod_0.jpg",
+    ]
+  end
+
+  before do
+    allow(Kontrast).to receive(:path).and_return(kontrast_path)
+  end
+
+  describe 'thumb_path' do
+    it 'should return a png' do
+      image_name = "diff_0.jpg"
+
+      thumb_path = Kontrast::ThumbnailCreator.thumb_path(test, image_name)
+
+      expect(thumb_path).to eql "#{kontrast_path}/#{test}/diff_0_thumb.png"
+    end
+  end
+
+  describe 'create_thumbnails' do
+    it 'creates thumbnails' do
+      allow(Kontrast::ThumbnailCreator).to receive(:`)
+
+      Kontrast::ThumbnailCreator.create_thumbnails(test, image_names)
+
+
+      expect(Kontrast::ThumbnailCreator).to have_received(:`).with(/^convert.*/).exactly(3).times
+    end
+  end
+end


### PR DESCRIPTION
When there are a lot of images to thumbnail, it's best not to load them
all into RAM first. In fact, we don't really need to load them at all in
order to thumbnail, just shell out to `convert`. That makes the ruby
garbage collector's job a bit easier.

In my local tests this keeps kontrast's memory usage around 500MB
instead of spiking up to 2.5GB.