### PR TITLE
Retry EOFErrors when waiting for the server to come up

### DIFF
--- a/lib/kontrast/global_runner.rb
+++ b/lib/kontrast/global_runner.rb
@@ -86,7 +86,7 @@ module Kontrast
                 uri = URI(Kontrast.configuration.test_domain)
                 begin
                     Net::HTTP.get(uri)
-                rescue Errno::ECONNREFUSED => e
+                rescue Errno::ECONNREFUSED, EOFError => e
                     tries -= 1
                     if tries > 0
                         puts "Waiting for test server..."


### PR DESCRIPTION
Time-consuming tasks that run on the first request to the server can cause the client to raise `EOFError` instead of `Errno:ECONNREFUSED` -- the server is up, it's just taking its sweet time. For example, slow asset compilation can be a culprit.